### PR TITLE
トップページのアプリ名のスマホ対応

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,4 +1,23 @@
+/* --- top--- */
+.top-title {
+  text-align:center;
+  font-family: 'Courgette', cursive;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 9em;
+  margin: 0.5em 0;
+}
+@media screen and (max-width: 768px) {
+  .top-title {
+    font-size: 4em 
+  }
+}
 
+@media screen and (max-width: 480px) {
+  .top-title {
+    font-size: 3em;
+  }
+}
 /* --- Application --- */
 body {
   margin: 0;

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,9 +1,8 @@
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link href="https://fonts.googleapis.com/css2?family=Courgette&family=Shantell+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
 
 <div style="text-align: center; ">
-  <h1 style="text-align: center; font-size: 9em; font-family: 'Courgette', cursive; font-weight: 400; font-style: normal;">
-  lunchoice
-  </h1>
+  <h1 class="top-title">lunchoice</h1>
   <h2>休日のランチ、決めてみませんか？</h2>
   
   <p style="margin-top: 25px; font-size: 1.2em; max-width: 600px; margin: 10px auto;">

--- a/log/development.log
+++ b/log/development.log
@@ -32540,3 +32540,194 @@ Processing by TopController#index as HTML
 Completed 200 OK in 4ms (Views: 4.2ms | ActiveRecord: 0.0ms | Allocations: 4418)
 
 
+Started GET "/" for 172.29.0.1 at 2026-04-02 14:39:41 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+  [1m[36mActiveRecord::SchemaMigration Load (2.7ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 3.2ms | Allocations: 916)
+  Rendered layout layouts/application.html.erb (Duration: 87.2ms | Allocations: 44032)
+Completed 200 OK in 391ms (Views: 90.4ms | ActiveRecord: 0.0ms | Allocations: 331005)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 14:48:47 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 5.8ms | Allocations: 1561)
+  Rendered layout layouts/application.html.erb (Duration: 86.7ms | Allocations: 27945)
+Completed 200 OK in 91ms (Views: 87.8ms | ActiveRecord: 0.0ms | Allocations: 29845)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 14:49:51 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 1.2ms | Allocations: 604)
+  Rendered layout layouts/application.html.erb (Duration: 12.4ms | Allocations: 23564)
+Completed 200 OK in 16ms (Views: 13.3ms | ActiveRecord: 0.0ms | Allocations: 25465)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 14:49:52 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.6ms | Allocations: 304)
+  Rendered layout layouts/application.html.erb (Duration: 4.8ms | Allocations: 4179)
+Completed 200 OK in 5ms (Views: 5.1ms | ActiveRecord: 0.0ms | Allocations: 4427)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 14:50:01 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.8ms | Allocations: 314)
+  Rendered layout layouts/application.html.erb (Duration: 5.5ms | Allocations: 4174)
+Completed 200 OK in 6ms (Views: 5.9ms | ActiveRecord: 0.0ms | Allocations: 4417)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 14:52:33 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.9ms | Allocations: 580)
+  Rendered layout layouts/application.html.erb (Duration: 12.2ms | Allocations: 23327)
+Completed 200 OK in 16ms (Views: 13.3ms | ActiveRecord: 0.0ms | Allocations: 25222)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 14:55:33 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.6ms | Allocations: 311)
+  Rendered layout layouts/application.html.erb (Duration: 8.5ms | Allocations: 5860)
+Completed 200 OK in 9ms (Views: 8.8ms | ActiveRecord: 0.0ms | Allocations: 6103)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 14:55:33 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.6ms | Allocations: 307)
+  Rendered layout layouts/application.html.erb (Duration: 4.2ms | Allocations: 4190)
+Completed 200 OK in 5ms (Views: 4.6ms | ActiveRecord: 0.0ms | Allocations: 4434)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 14:57:24 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.6ms | Allocations: 299)
+  Rendered layout layouts/application.html.erb (Duration: 5.4ms | Allocations: 4168)
+Completed 200 OK in 6ms (Views: 5.7ms | ActiveRecord: 0.0ms | Allocations: 4412)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 15:01:28 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 1.4ms | Allocations: 587)
+  Rendered layout layouts/application.html.erb (Duration: 13.2ms | Allocations: 23530)
+Completed 200 OK in 17ms (Views: 14.2ms | ActiveRecord: 0.0ms | Allocations: 25428)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 15:01:35 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.7ms | Allocations: 344)
+  Rendered layout layouts/application.html.erb (Duration: 4.3ms | Allocations: 4204)
+Completed 200 OK in 5ms (Views: 4.7ms | ActiveRecord: 0.0ms | Allocations: 4447)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 15:01:37 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.8ms | Allocations: 308)
+  Rendered layout layouts/application.html.erb (Duration: 4.4ms | Allocations: 4168)
+Completed 200 OK in 5ms (Views: 4.7ms | ActiveRecord: 0.0ms | Allocations: 4411)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 15:01:37 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.7ms | Allocations: 314)
+  Rendered layout layouts/application.html.erb (Duration: 5.4ms | Allocations: 4210)
+Completed 200 OK in 6ms (Views: 5.7ms | ActiveRecord: 0.0ms | Allocations: 4455)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 15:01:38 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.8ms | Allocations: 313)
+  Rendered layout layouts/application.html.erb (Duration: 6.4ms | Allocations: 4206)
+Completed 200 OK in 7ms (Views: 6.8ms | ActiveRecord: 0.0ms | Allocations: 4450)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 15:01:38 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 2.3ms | Allocations: 323)
+  Rendered layout layouts/application.html.erb (Duration: 7.1ms | Allocations: 4186)
+Completed 200 OK in 8ms (Views: 7.7ms | ActiveRecord: 0.0ms | Allocations: 4429)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 15:01:38 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 1.1ms | Allocations: 308)
+  Rendered layout layouts/application.html.erb (Duration: 6.4ms | Allocations: 4168)
+Completed 200 OK in 7ms (Views: 6.9ms | ActiveRecord: 0.0ms | Allocations: 4411)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 15:02:07 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 1.0ms | Allocations: 597)
+  Rendered layout layouts/application.html.erb (Duration: 11.5ms | Allocations: 23530)
+Completed 200 OK in 15ms (Views: 12.4ms | ActiveRecord: 0.0ms | Allocations: 25428)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 15:07:10 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.7ms | Allocations: 314)
+  Rendered layout layouts/application.html.erb (Duration: 17.0ms | Allocations: 5858)
+Completed 200 OK in 18ms (Views: 17.4ms | ActiveRecord: 0.0ms | Allocations: 6101)
+
+
+Started GET "/" for 172.29.0.1 at 2026-04-02 15:08:04 +0000
+Cannot render console from 172.29.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
+Processing by TopController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering top/index.html.erb within layouts/application
+  Rendered top/index.html.erb within layouts/application (Duration: 0.8ms | Allocations: 320)
+  Rendered layout layouts/application.html.erb (Duration: 9.9ms | Allocations: 5892)
+Completed 200 OK in 11ms (Views: 10.3ms | ActiveRecord: 0.0ms | Allocations: 6136)
+
+


### PR DESCRIPTION
概要
トップページに表示されているアプリ名「lunchoice」のレスポンシブ対応を行いました。

目的
スマホで表示したときにアプリ名が見切れてしまいユーザー体験を損ねてしまっていたため

変更点
768ｐｘ以下でフォントサイズを４em、480px以下で3emで表示されるようにしました。
アプリ表示のCSSをスタイルシートに移動しました。

動作確認
ローカル環境で確認後にデプロイ環境のPCとスマホで正しく表示されることを確認しました