### PR TITLE
サインアップ画面にgoogle認証のボタン追加

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -32,6 +32,16 @@
     </div>
   <% end %>
 
+    <div class="omniauth-section">
+      <div class="separator">または</div>
+      <%= button_to user_google_oauth2_omniauth_authorize_path, 
+                     method: :post, 
+                     data: { turbo: false }, 
+                     class: "btn-google" do %>
+        <span class="google-icon">G</span> Googleでログイン
+      <% end %>
+    </div>
+
   <div class="auth-links">
     <%= link_to "トップページへ", root_path %> | 
     <%= link_to "ログインへ", new_user_session_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   devise_for :users,controllers: {
     registrations: 'users/registrations',
-    omniauth_callbacks: 'users/omniauth_callbacks'
+    omniauth_callbacks: 'users/omniauth_callbacks',
   }
   
   root 'top#index'


### PR DESCRIPTION
概要
サインアップ画面にgoogle認証が表示されるようにしました。

目的
google認証を行うことができるようにしていたがログイン画面には表示するように記述していたがサインアップ画面に表示されるようになってなかったため

変更点
サインアップ画面の登録ボタン下部にgoogle認証のための動線を設置しました。

動作確認
ローカル環境で確認済みでこのブランチで本番環境のテストを行います